### PR TITLE
Update Rails to 5.2.4.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'jquery-turbolinks'
-gem 'rails', '~> 5.2.4', '>= 5.2.4.3'
+gem 'rails', '~> 5.2.4', '>= 5.2.4.4'
 ruby '2.6.5'
 
 gem 'bootsnap', '>= 1.1.0', require: false # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ DEPENDENCIES
   nokogiri (= 1.10.10)
   pg (= 1.2.3)
   puma (= 5.0.2)
-  rails (~> 5.2.4, >= 5.2.4.3)
+  rails (~> 5.2.4, >= 5.2.4.4)
   rspec-rails (~> 4.0.1)
   rubocop (~> 0.93.1)
   sass-rails (~> 5.0)


### PR DESCRIPTION
This should eliminate the GitHub Dependabot warnings